### PR TITLE
Fix/duplicate inputs

### DIFF
--- a/nodes/Stellar/actions/payments/pathPaymentStrictReceive/description.ts
+++ b/nodes/Stellar/actions/payments/pathPaymentStrictReceive/description.ts
@@ -194,6 +194,8 @@ export const pathPaymentStrictReceiveDescription: INodeProperties[] = [
 		],
 		displayOptions: {
 			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictReceive'],
 				isDestinationAssetNative: [false],
 			},
 		},

--- a/nodes/Stellar/actions/payments/pathPaymentStrictSend/description.ts
+++ b/nodes/Stellar/actions/payments/pathPaymentStrictSend/description.ts
@@ -192,6 +192,8 @@ export const pathPaymentStrictSendDescription: INodeProperties[] = [
 		],
 		displayOptions: {
 			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictSend'],
 				isDestinationAssetNative: [false],
 			},
 		},

--- a/nodes/Stellar/actions/swapAssets/swap/description.ts
+++ b/nodes/Stellar/actions/swapAssets/swap/description.ts
@@ -174,6 +174,8 @@ export const swapAssetsDescription: INodeProperties[] = [
 		],
 		displayOptions: {
 			show: {
+				resource: ['swapAssets'],
+				operation: ['swap'],
 				isDestinationAssetNative: [false],
 			},
 		},

--- a/nodes/Stellar/actions/swapAssets/swap/description.ts
+++ b/nodes/Stellar/actions/swapAssets/swap/description.ts
@@ -118,6 +118,8 @@ export const swapAssetsDescription: INodeProperties[] = [
 		],
 		displayOptions: {
 			show: {
+				resource: ['swapAssets'],
+				operation: ['swap'],
 				isSourceAssetNative: [false],
 			},
 		},


### PR DESCRIPTION
# Summary

This PR will fix an error that was causing duplicate inputs appears in the UI of certain nodes

# Details

Three inputs were having the same name, and when an option was selected it will refer to the three inputs and the three will show in the UI, I just had to specify in which node I wanted to show the Fixed Collection when the option was selected