### PR TITLE
Fix/sep12 files

### DIFF
--- a/nodes/Anclap/transport/SEP12.ts
+++ b/nodes/Anclap/transport/SEP12.ts
@@ -126,8 +126,6 @@ export default class SEP12 {
 
 		const imageFormat = getImageFormatFromBase64(request.file);
 		if (!imageFormat) {
-			const supportedFormats = Object.keys(imageFormats).join(', ');
-
 			throw new Error(`Invalid image format, try again.`);
 		}
 

--- a/nodes/Anclap/transport/SEP12.ts
+++ b/nodes/Anclap/transport/SEP12.ts
@@ -11,6 +11,7 @@ import AxiosHttpRequestError from './errors/AxiosHttpRequestError';
 import PayloadBuilder from './utils/PayloadBuilder';
 import convertToSnakeCase from './utils/convertToSnakeCase';
 import { IBaseStandardFieldsRequest } from './requests/StandardFieldsRequest/IBaseStandardFieldsRequest';
+import FormData from 'form-data';
 
 export default class SEP12 {
 	private anclapCredentials: AnclapCredentials;
@@ -122,11 +123,15 @@ export default class SEP12 {
 	async uploadBinaryFile(request: IBinaryFieldRequest) {
 		const toml = await this.anclapCredentials.getToml();
 
-		try {
-			const fileId = await axios.post(`${toml.KYC_SERVER}/customer/files`, request, {
-				headers: { Authorization: `Bearer ${this.token}` },
-			});
+		const imageBuffer = Buffer.from(request.file, 'base64');
 
+		const formData = new FormData();
+		formData.append('file', imageBuffer, 'file.jpeg');
+		try {
+			const fileId = await axios.post(`${toml.KYC_SERVER}/customer/files`, formData, {
+				headers: { Authorization: `Bearer ${this.token}`,
+				'Content-Type': 'multipart/form-data'},
+			});
 			return fileId.data;
 		} catch (e) {
 			throw new AxiosHttpRequestError(e);

--- a/nodes/Anclap/transport/utils/imageFormatFromBase64.ts
+++ b/nodes/Anclap/transport/utils/imageFormatFromBase64.ts
@@ -1,0 +1,23 @@
+export function getImageFormatFromBase64(base64String: string): string | null {
+	const headerFormatLength = 30;
+	const header = base64String.substring(0, headerFormatLength);
+
+	for (const format in imageFormats) {
+		if (header.startsWith(imageFormats[format])) {
+			return format;
+		}
+	}
+
+	return null;
+}
+export const imageFormats: Record<string, string> = {
+	jpeg: '/9j/4',
+	png: 'iVBORw0KGgoAAAANSUhEUgAA',
+	gif: 'R0lGODlh',
+	webp: 'UklGR',
+	bmp: 'Qk02',
+	tiff: 'SUkq',
+	ico: 'AAAB',
+	svg: 'PHN2Zy',
+	pdf: 'JVBERi0'
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.6",
+				"@types/form-data": "^2.5.0",
+				"@types/node": "^20.4.6",
 				"@types/request-promise-native": "~1.0.15",
 				"@typescript-eslint/parser": "~5.45",
 				"eslint-plugin-n8n-nodes-base": "^1.11.0",
@@ -213,6 +215,16 @@
 				"@types/range-parser": "*"
 			}
 		},
+		"node_modules/@types/form-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
+			"integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
+			"deprecated": "This is a stub types definition. form-data provides its own type definitions, so you do not need this installed.",
+			"dev": true,
+			"dependencies": {
+				"form-data": "*"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -226,9 +238,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.0.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-			"integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw=="
+			"version": "20.4.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.6.tgz",
+			"integrity": "sha512-q0RkvNgMweWWIvSMDiXhflGUKMdIxBo2M2tYM/0kEGDueQByFzK4KZAgu5YHGFNxziTlppNpTIBcqHQAxlfHdA=="
 		},
 		"node_modules/@types/qs": {
 			"version": "6.9.7",
@@ -8826,6 +8838,15 @@
 				"@types/range-parser": "*"
 			}
 		},
+		"@types/form-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
+			"integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
+			"dev": true,
+			"requires": {
+				"form-data": "*"
+			}
+		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -8839,9 +8860,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.0.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-			"integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw=="
+			"version": "20.4.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.6.tgz",
+			"integrity": "sha512-q0RkvNgMweWWIvSMDiXhflGUKMdIxBo2M2tYM/0kEGDueQByFzK4KZAgu5YHGFNxziTlppNpTIBcqHQAxlfHdA=="
 		},
 		"@types/qs": {
 			"version": "6.9.7",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.6",
+		"@types/form-data": "^2.5.0",
+		"@types/node": "^20.4.6",
 		"@types/request-promise-native": "~1.0.15",
 		"@typescript-eslint/parser": "~5.45",
 		"eslint-plugin-n8n-nodes-base": "^1.11.0",


### PR DESCRIPTION
# Summary

This PR fixes the uploading of binary files for the SEP12 KYC.

# Details

* It converts the base64-encoded binary file data passed in `request.file` into a `Buffer`, which is a Node.js data structure for handling binary data.
* It creates a new instance of the `FormData` class. FormData is a built-in browser and Node.js API used for creating multipart/form-data HTTP requests, which are commonly used for uploading files.
* It appends the `imageBuffer` (Buffer containing the file data) to the `FormData` object with the field name 'file' and the filename 'file.jpeg'.
* It will return a `file_id` to be used in subsequent `PUT /customer` requests.

# Evidence

<img src="https://github.com/ScaleMote/flow/assets/55992031/e6d285df-e421-44ff-91cb-a85daf6ee57e"></img>

# References

📖  [SEP-12 customer files documentation](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-files)
