### PR TITLE
Feature/soroban payments

### DIFF
--- a/nodes/Soroban/Soroban.node.ts
+++ b/nodes/Soroban/Soroban.node.ts
@@ -5,6 +5,7 @@ import {
 	INodeTypeDescription,
 } from 'n8n-workflow';
 import { router } from './actions/router';
+import * as payments from './actions/payments';
 
 export class Soroban implements INodeType {
 	description: INodeTypeDescription = {
@@ -26,12 +27,18 @@ export class Soroban implements INodeType {
 				displayName: 'Resource',
 				name: 'resource',
 				type: 'options',
-				default: '',
-				options: [],
+				default: 'payments',
+				options: [
+					{
+						name: 'Payment',
+						value: 'payments',
+					},
+				],
 				noDataExpression: true,
 				required: true,
 				description: 'Operation Type:',
 			},
+			...payments.description,
 		],
 	};
 

--- a/nodes/Soroban/actions/entities/ISorobanNode.ts
+++ b/nodes/Soroban/actions/entities/ISorobanNode.ts
@@ -2,10 +2,13 @@ import type { AllEntities, Entity, PropertiesOf } from 'n8n-workflow';
 
 export type SorobanResources = {
 	newAccount: 'createAccount';
+	payments: 'getPayment' | 'makePayment' | 'pathPaymentStrictSend' | 'pathPaymentStrictReceive';
 };
 
 export type Soroban = AllEntities<SorobanResources>;
 
 type SorobanNewAccount = Entity<SorobanResources, 'newAccount'>;
+type SorobanPayments = Entity<SorobanResources, 'payments'>;
 
 export type NewAccountProperties = PropertiesOf<SorobanNewAccount>;
+export type PaymentsProperties = PropertiesOf<SorobanPayments>;

--- a/nodes/Soroban/actions/payments/description.ts
+++ b/nodes/Soroban/actions/payments/description.ts
@@ -1,0 +1,46 @@
+import { INodeProperties } from 'n8n-workflow';
+import * as makePayment from './makePayment';
+import * as pathPaymentStrictSend from './pathPaymentStrictSend';
+import * as pathPaymentStrictReceive from './pathPaymentStrictReceive';
+
+const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		default: 'makePayment',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+			},
+		},
+		options: [
+			{
+				name: 'Make Payment',
+				value: 'makePayment',
+				description: 'Sends an specific asset to a destination account',
+				action: 'Make payment',
+			},
+			{
+				name: 'Path Payment Strict Send',
+				value: 'pathPaymentStrictSend',
+				description:
+					'Sends an amount in a specific asset to a destination account through a path of offer',
+				action: 'Make path payment strict send',
+			},
+			{
+				name: 'Path Payment Strict Receive',
+				value: 'pathPaymentStrictReceive',
+				description:
+					'Sends an amount in a specific asset to a destination account through a path of offer',
+				action: 'Make path payment strict  receive',
+			},
+		],
+	},
+	...makePayment.description,
+	...pathPaymentStrictSend.description,
+	...pathPaymentStrictReceive.description,
+];
+
+export default description;

--- a/nodes/Soroban/actions/payments/index.ts
+++ b/nodes/Soroban/actions/payments/index.ts
@@ -1,0 +1,6 @@
+import * as makePayment from './makePayment';
+import * as pathPaymentStrictSend from './pathPaymentStrictSend';
+import * as pathPaymentStrictReceive from './pathPaymentStrictReceive';
+import description from './description';
+
+export { makePayment, pathPaymentStrictSend, pathPaymentStrictReceive, description };

--- a/nodes/Soroban/actions/payments/makePayment/description.ts
+++ b/nodes/Soroban/actions/payments/makePayment/description.ts
@@ -1,4 +1,4 @@
-import { PaymentsProperties } from '../../entities/ISorobanNode';
+import { PaymentsProperties } from '../../entities/SorobanNode';
 
 export const makePaymentDescription: PaymentsProperties = [
 	{

--- a/nodes/Soroban/actions/payments/makePayment/description.ts
+++ b/nodes/Soroban/actions/payments/makePayment/description.ts
@@ -1,0 +1,101 @@
+import { PaymentsProperties } from '../../entities/ISorobanNode';
+
+export const makePaymentDescription: PaymentsProperties = [
+	{
+		displayName: 'Destination Account',
+		name: 'destinationAccount',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['makePayment'],
+			},
+		},
+		default: '',
+		placeholder: 'GCEVJ...',
+		description: 'Account public key',
+	},
+	{
+		displayName: 'Asset',
+		name: 'destinationAsset',
+		type: 'fixedCollection',
+		default: {},
+		required: true,
+		placeholder: 'Select asset',
+		typeOptions: {
+			multipleValues: false,
+		},
+		options: [
+			{
+				name: 'values',
+				displayName: 'Asset',
+				values: [
+					{
+						displayName: 'Asset Type',
+						name: 'isNative',
+						type: 'options',
+						required: true,
+						options: [
+							{
+								name: 'Native',
+								value: true,
+							},
+							{
+								name: 'Custom Asset',
+								value: false,
+							},
+						],
+						default: true,
+					},
+					{
+						displayName: 'Code',
+						name: 'code',
+						type: 'string',
+						default: '',
+						required: true,
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+					{
+						displayName: 'Issuer',
+						name: 'issuer',
+						type: 'string',
+						default: '',
+						required: true,
+						placeholder: 'GCEVJ...',
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+				],
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['makePayment'],
+			},
+		},
+		description: 'Asset held by the destination account',
+	},
+	{
+		displayName: 'Amount',
+		name: 'amount',
+		type: 'number',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['makePayment'],
+			},
+		},
+		default: '',
+		description: 'Amount to be transfer',
+	},
+];

--- a/nodes/Soroban/actions/payments/makePayment/execute.ts
+++ b/nodes/Soroban/actions/payments/makePayment/execute.ts
@@ -1,0 +1,23 @@
+import { IExecuteFunctions } from 'n8n-workflow';
+import { Asset, Operation } from 'soroban-client';
+import { convertAmountToBigNumber } from '../../../../../common/utils/stellar/convertAmountToBigNumber';
+import IAsset from '../../../../../common/interfaces/stellar/IAsset';
+import { buildAsset } from '../../../../../common/utils/stellar/buildAsset';
+import { StellarPlatformEnum } from '../../../../../common/enum/stellar/StellarPlatformEnum';
+
+export async function makePayment(this: IExecuteFunctions) {
+	try {
+		const destination = this.getNodeParameter('destinationAccount', 0) as string;
+		const { values: destinationAsset } = this.getNodeParameter('destinationAsset', 0) as IAsset;
+		const paymentAmount = this.getNodeParameter('amount', 0) as number;
+
+		const asset = buildAsset(destinationAsset, StellarPlatformEnum.SOROBAN) as Asset;
+		const amount = convertAmountToBigNumber(paymentAmount);
+
+		const paymentOperation = Operation.payment({ amount, asset, destination }).toXDR('base64');
+
+		return { operation: paymentOperation };
+	} catch (error) {
+		throw new Error(error);
+	}
+}

--- a/nodes/Soroban/actions/payments/makePayment/index.ts
+++ b/nodes/Soroban/actions/payments/makePayment/index.ts
@@ -1,0 +1,4 @@
+import { makePaymentDescription as description } from './description';
+import { makePayment as execute } from './execute';
+
+export { description, execute };

--- a/nodes/Soroban/actions/payments/pathPaymentStrictReceive/description.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictReceive/description.ts
@@ -1,0 +1,266 @@
+import { PaymentsProperties } from '../../entities/ISorobanNode';
+
+export const pathPaymentStrictReceiveDescription: PaymentsProperties = [
+	{
+		displayName: 'Destination Account',
+		name: 'destinationAccount',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictReceive'],
+			},
+		},
+		default: '',
+		placeholder: 'GCEVJ...',
+		description: 'Account public key',
+	},
+	{
+		displayName: 'Sending Asset',
+		name: 'sendingAsset',
+		type: 'fixedCollection',
+		default: {},
+		required: true,
+		placeholder: 'Select asset',
+		typeOptions: {
+			multipleValues: false,
+		},
+		options: [
+			{
+				name: 'values',
+				displayName: 'Asset',
+				values: [
+					{
+						displayName: 'Asset Type',
+						name: 'isNative',
+						type: 'options',
+						required: true,
+						options: [
+							{
+								name: 'Native',
+								value: true,
+							},
+							{
+								name: 'Custom Asset',
+								value: false,
+							},
+						],
+						default: true,
+					},
+					{
+						displayName: 'Code',
+						name: 'code',
+						type: 'string',
+						default: '',
+						required: true,
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+					{
+						displayName: 'Issuer',
+						name: 'issuer',
+						type: 'string',
+						default: '',
+						required: true,
+						placeholder: 'GCEVJ...',
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+				],
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictReceive'],
+			},
+		},
+		description: 'Asset held by the destination account',
+	},
+	{
+		displayName: 'Maximum Send Amount',
+		name: 'maxSendAmount',
+		type: 'number',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictReceive'],
+			},
+		},
+		default: '',
+		description:
+			'The most the sender is willing to spend to take the paths to. Resulting amount may vary due to the offers in the orderbook.',
+	},
+	{
+		displayName: 'Intermediate Path',
+		name: 'intermediatePathAssets',
+		type: 'fixedCollection',
+		default: {},
+		placeholder: 'Add new intermediate asset',
+		typeOptions: {
+			multipleValues: true,
+			multipleValueButtonText: 'Add new intermediate asset',
+		},
+		options: [
+			{
+				name: 'values',
+				displayName: 'Asset',
+				values: [
+					{
+						displayName: 'Asset Type',
+						name: 'isNative',
+						type: 'options',
+						required: true,
+						options: [
+							{
+								name: 'Native',
+								value: true,
+							},
+							{
+								name: 'Custom Asset',
+								value: false,
+							},
+						],
+						default: true,
+					},
+					{
+						displayName: 'Code',
+						name: 'code',
+						type: 'string',
+						default: '',
+						required: true,
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+					{
+						displayName: 'Issuer',
+						name: 'issuer',
+						type: 'string',
+						default: '',
+						required: true,
+						placeholder: 'GCEVJ...',
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+				],
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictReceive'],
+			},
+		},
+		description:
+			'The assets (other than send asset and destination asset) involved in the offers the path takes',
+	},
+	{
+		displayName: 'Destination Asset',
+		name: 'destinationAsset',
+		type: 'fixedCollection',
+		default: {},
+		required: true,
+		placeholder: 'Select asset',
+		typeOptions: {
+			multipleValues: false,
+		},
+		options: [
+			{
+				name: 'values',
+				displayName: 'Asset',
+				values: [
+					{
+						displayName: 'Asset Type',
+						name: 'isNative',
+						type: 'options',
+						required: true,
+						options: [
+							{
+								name: 'Native',
+								value: true,
+							},
+							{
+								name: 'Custom Asset',
+								value: false,
+							},
+						],
+						default: true,
+					},
+					{
+						displayName: 'Code',
+						name: 'code',
+						type: 'string',
+						default: '',
+						required: true,
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+					{
+						displayName: 'Issuer',
+						name: 'issuer',
+						type: 'string',
+						default: '',
+						required: true,
+						placeholder: 'GCEVJ...',
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+				],
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictReceive'],
+			},
+		},
+		description: 'The asset the destination account receives',
+	},
+	{
+		displayName: 'Destination Amount',
+		name: 'destinationAmount',
+		type: 'number',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictReceive'],
+			},
+		},
+		default: '',
+	},
+	{
+		displayName: 'Source Account',
+		name: 'sourceAccount',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictReceive'],
+			},
+		},
+		default: '',
+		placeholder: 'GCEVJ...',
+		description: 'Account public key',
+	},
+];

--- a/nodes/Soroban/actions/payments/pathPaymentStrictReceive/description.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictReceive/description.ts
@@ -1,4 +1,4 @@
-import { PaymentsProperties } from '../../entities/ISorobanNode';
+import { PaymentsProperties } from '../../entities/SorobanNode';
 
 export const pathPaymentStrictReceiveDescription: PaymentsProperties = [
 	{

--- a/nodes/Soroban/actions/payments/pathPaymentStrictReceive/execute.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictReceive/execute.ts
@@ -1,0 +1,46 @@
+import { IExecuteFunctions } from 'n8n-workflow';
+import { Asset, Operation } from 'stellar-sdk';
+import { convertAmountToBigNumber } from '../../../../../common/utils/stellar/convertAmountToBigNumber';
+import IAssetsPath from '../../../../../common/interfaces/stellar/IAssetsPath';
+import IAsset from '../../../../../common/interfaces/stellar/IAsset';
+import { buildAsset } from '../../../../../common/utils/stellar/buildAsset';
+import { StellarPlatformEnum } from '../../../../../common/enum/stellar/StellarPlatformEnum';
+
+export async function pathPaymentStrictReceive(this: IExecuteFunctions) {
+	try {
+		const { values: sendingAsset } = this.getNodeParameter('sendingAsset', 0) as IAsset;
+		const maxSendingAmount = this.getNodeParameter('maxSendAmount', 0) as number;
+		const destination = this.getNodeParameter('destinationAccount', 0) as string;
+		const { values: destinationAsset } = this.getNodeParameter('destinationAsset', 0) as IAsset;
+		const destinationAmount = this.getNodeParameter('destinationAmount', 0) as number;
+		const { values: intermediateAssets } = this.getNodeParameter(
+			'intermediatePathAssets',
+			0,
+			[],
+		) as IAssetsPath;
+
+		const sendAsset = buildAsset(sendingAsset, StellarPlatformEnum.SOROBAN) as Asset;
+		const sendMax = convertAmountToBigNumber(maxSendingAmount);
+		const destAsset = buildAsset(destinationAsset, StellarPlatformEnum.SOROBAN) as Asset;
+		const destAmount = convertAmountToBigNumber(destinationAmount);
+		let path: Asset[] = [];
+
+		intermediateAssets.forEach((asset) => {
+			const intermediateAsset = buildAsset(asset, StellarPlatformEnum.SOROBAN) as Asset;
+			path.push(intermediateAsset);
+		});
+
+		let pathPaymentStrictReceiveOperation = Operation.pathPaymentStrictReceive({
+			sendAsset,
+			sendMax,
+			destination,
+			destAsset,
+			destAmount,
+			path,
+		}).toXDR('base64');
+
+		return { operation: pathPaymentStrictReceiveOperation };
+	} catch (error) {
+		throw new Error(error);
+	}
+}

--- a/nodes/Soroban/actions/payments/pathPaymentStrictReceive/index.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictReceive/index.ts
@@ -1,0 +1,4 @@
+import { pathPaymentStrictReceiveDescription as description } from './description';
+import { pathPaymentStrictReceive as execute } from './execute';
+
+export { description, execute };

--- a/nodes/Soroban/actions/payments/pathPaymentStrictSend/description.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictSend/description.ts
@@ -1,4 +1,4 @@
-import { PaymentsProperties } from '../../entities/ISorobanNode';
+import { PaymentsProperties } from '../../entities/SorobanNode';
 
 export const pathPaymentStrictSendDescription: PaymentsProperties = [
 	{

--- a/nodes/Soroban/actions/payments/pathPaymentStrictSend/description.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictSend/description.ts
@@ -1,0 +1,252 @@
+import { PaymentsProperties } from '../../entities/ISorobanNode';
+
+export const pathPaymentStrictSendDescription: PaymentsProperties = [
+	{
+		displayName: 'Destination Account',
+		name: 'destinationAccount',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictSend'],
+			},
+		},
+		default: '',
+		placeholder: 'GCEVJ...',
+		description: 'Account public key',
+	},
+	{
+		displayName: 'Sending Asset',
+		name: 'sendingAsset',
+		type: 'fixedCollection',
+		default: {},
+		required: true,
+		placeholder: 'Select asset',
+		typeOptions: {
+			multipleValues: false,
+		},
+		options: [
+			{
+				name: 'values',
+				displayName: 'Asset',
+				values: [
+					{
+						displayName: 'Asset Type',
+						name: 'isNative',
+						type: 'options',
+						required: true,
+						options: [
+							{
+								name: 'Native',
+								value: true,
+							},
+							{
+								name: 'Custom Asset',
+								value: false,
+							},
+						],
+						default: true,
+					},
+					{
+						displayName: 'Code',
+						name: 'code',
+						type: 'string',
+						default: '',
+						required: true,
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+					{
+						displayName: 'Issuer',
+						name: 'issuer',
+						type: 'string',
+						default: '',
+						required: true,
+						placeholder: 'GCEVJ...',
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+				],
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictSend'],
+			},
+		},
+		description: 'Asset held by the destination account',
+	},
+	{
+		displayName: 'Send Amount',
+		name: 'sendAmount',
+		type: 'number',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictSend'],
+			},
+		},
+		default: '',
+		description: 'Amount to be transfer',
+	},
+	{
+		displayName: 'Intermediate Path',
+		name: 'intermediatePathAssets',
+		type: 'fixedCollection',
+		default: {},
+		placeholder: 'Add new intermediate asset',
+		typeOptions: {
+			multipleValues: true,
+			multipleValueButtonText: 'Add new intermediate asset',
+		},
+		options: [
+			{
+				name: 'values',
+				displayName: 'Asset',
+				values: [
+					{
+						displayName: 'Asset Type',
+						name: 'isNative',
+						type: 'options',
+						required: true,
+						options: [
+							{
+								name: 'Native',
+								value: true,
+							},
+							{
+								name: 'Custom Asset',
+								value: false,
+							},
+						],
+						default: true,
+					},
+					{
+						displayName: 'Code',
+						name: 'code',
+						type: 'string',
+						default: '',
+						required: true,
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+					{
+						displayName: 'Issuer',
+						name: 'issuer',
+						type: 'string',
+						default: '',
+						required: true,
+						placeholder: 'GCEVJ...',
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+				],
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictSend'],
+			},
+		},
+		description:
+			'The assets (other than send asset and destination asset) involved in the offers the path takes',
+	},
+	{
+		displayName: 'Destination Asset',
+		name: 'destinationAsset',
+		type: 'fixedCollection',
+		default: {},
+		required: true,
+		placeholder: 'Select asset',
+		typeOptions: {
+			multipleValues: false,
+		},
+		options: [
+			{
+				name: 'values',
+				displayName: 'Asset',
+				values: [
+					{
+						displayName: 'Asset Type',
+						name: 'isNative',
+						type: 'options',
+						required: true,
+						options: [
+							{
+								name: 'Native',
+								value: true,
+							},
+							{
+								name: 'Custom Asset',
+								value: false,
+							},
+						],
+						default: true,
+					},
+					{
+						displayName: 'Code',
+						name: 'code',
+						type: 'string',
+						default: '',
+						required: true,
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+					{
+						displayName: 'Issuer',
+						name: 'issuer',
+						type: 'string',
+						default: '',
+						required: true,
+						placeholder: 'GCEVJ...',
+						displayOptions: {
+							show: {
+								isNative: [false],
+							},
+						},
+					},
+				],
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictSend'],
+			},
+		},
+		description: 'The asset the destination account receives',
+	},
+	{
+		displayName: 'Minimum Destination Amount',
+		name: 'minDestinationAmount',
+		type: 'number',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['payments'],
+				operation: ['pathPaymentStrictSend'],
+			},
+		},
+		default: '',
+		description: 'The minimum amount the destination can receive',
+	},
+];

--- a/nodes/Soroban/actions/payments/pathPaymentStrictSend/execute.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictSend/execute.ts
@@ -1,0 +1,46 @@
+import { IExecuteFunctions } from 'n8n-workflow';
+import { Asset, Operation } from 'stellar-sdk';
+import { convertAmountToBigNumber } from '../../../../../common/utils/stellar/convertAmountToBigNumber';
+import IAssetsPath from '../../../../../common/interfaces/stellar/IAssetsPath';
+import IAsset from '../../../../../common/interfaces/stellar/IAsset';
+import { buildAsset } from '../../../../../common/utils/stellar/buildAsset';
+import { StellarPlatformEnum } from '../../../../../common/enum/stellar/StellarPlatformEnum';
+
+export async function pathPaymentStrictSend(this: IExecuteFunctions) {
+	try {
+		const { values: sendingAsset } = this.getNodeParameter('sendingAsset', 0) as IAsset;
+		const sendingAmount = this.getNodeParameter('sendAmount', 0) as number;
+		const destination = this.getNodeParameter('destinationAccount', 0) as string;
+		const { values: destinationAsset } = this.getNodeParameter('destinationAsset', 0) as IAsset;
+		const minDestinationAmount = this.getNodeParameter('minDestinationAmount', 0) as number;
+		const { values: intermediateAssets } = this.getNodeParameter(
+			'intermediatePathAssets',
+			0,
+			[],
+		) as IAssetsPath;
+
+		const sendAsset = buildAsset(sendingAsset, StellarPlatformEnum.SOROBAN) as Asset;
+		const sendAmount = convertAmountToBigNumber(sendingAmount);
+		const destAsset = buildAsset(destinationAsset, StellarPlatformEnum.SOROBAN) as Asset;
+		const destMin = convertAmountToBigNumber(minDestinationAmount);
+		let path: Asset[] = [];
+
+		intermediateAssets.forEach((asset) => {
+			const intermediateAsset = buildAsset(asset, StellarPlatformEnum.SOROBAN) as Asset;
+			path.push(intermediateAsset);
+		});
+
+		let pathPaymentStrictSendOperation = Operation.pathPaymentStrictSend({
+			sendAsset,
+			sendAmount,
+			destination,
+			destAsset,
+			destMin,
+			path,
+		}).toXDR('base64');
+
+		return { operation: pathPaymentStrictSendOperation };
+	} catch (error) {
+		throw new Error(error);
+	}
+}

--- a/nodes/Soroban/actions/payments/pathPaymentStrictSend/execute.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictSend/execute.ts
@@ -30,7 +30,7 @@ export async function pathPaymentStrictSend(this: IExecuteFunctions) {
 			path.push(intermediateAsset);
 		});
 
-		let pathPaymentStrictSendOperation = Operation.pathPaymentStrictSend({
+		const pathPaymentStrictSendOperation = Operation.pathPaymentStrictSend({
 			sendAsset,
 			sendAmount,
 			destination,

--- a/nodes/Soroban/actions/payments/pathPaymentStrictSend/index.ts
+++ b/nodes/Soroban/actions/payments/pathPaymentStrictSend/index.ts
@@ -1,0 +1,4 @@
+import { pathPaymentStrictSendDescription as description } from './description';
+import { pathPaymentStrictSend as execute } from './execute';
+
+export { description, execute };

--- a/nodes/Soroban/actions/resources.ts
+++ b/nodes/Soroban/actions/resources.ts
@@ -1,4 +1,5 @@
 import { SorobanResources } from './entities/ISorobanNode';
+import { makePayment, pathPaymentStrictReceive, pathPaymentStrictSend } from './payments';
 
 interface IOperations {
 	operations: { [key: string]: { execute: () => Promise<{}> | {} } };
@@ -7,6 +8,13 @@ interface IOperations {
 const resources: { [key in keyof SorobanResources]: IOperations } = {
 	newAccount: {
 		operations: {},
+	},
+	payments: {
+		operations: {
+			makePayment: { execute: makePayment.execute },
+			pathPaymentStrictReceive: { execute: pathPaymentStrictReceive.execute },
+			pathPaymentStrictSend: { execute: pathPaymentStrictSend.execute },
+		},
 	},
 };
 

--- a/nodes/Stellar/actions/payments/pathPaymentStrictSend/execute.ts
+++ b/nodes/Stellar/actions/payments/pathPaymentStrictSend/execute.ts
@@ -30,7 +30,7 @@ export async function pathPaymentStrictSend(this: IExecuteFunctions) {
 			path.push(intermediateAsset);
 		});
 
-		let pathPaymentStrictSendOperation = Operation.pathPaymentStrictSend({
+		const pathPaymentStrictSendOperation = Operation.pathPaymentStrictSend({
 			sendAsset,
 			sendAmount,
 			destination,


### PR DESCRIPTION
# Summary

This PR adds nodes for `payments`: `makePayment`, `pathPaymentStrictReceive` y `pathPaymentStrictSend` in the Soroban platform through n8n.

# Details

- Add makePayment node
- Add pathPaymentStrictReceive node
- Add pathPaymentStrictSend`node

# Evidence

![image](https://github.com/ScaleMote/flow/assets/63201795/4643baa5-1e18-4588-9fd5-2f4c44cf1732)
![image](https://github.com/ScaleMote/flow/assets/63201795/43865fd3-5a60-4b34-8f75-02b44ac2e8e4)
![image](https://github.com/ScaleMote/flow/assets/63201795/5380a31f-8e10-4f20-97a2-d11e2e925fb5)
![image](https://github.com/ScaleMote/flow/assets/63201795/1f546804-079f-4603-ac4a-a90008445061)

# References

📖 [JS Soroban Client](https://stellar.github.io/js-soroban-client/)
