### PR TITLE
Feature/soroban fund account

### DIFF
--- a/common/errors/stellar/InvalidPublicKeyError.ts
+++ b/common/errors/stellar/InvalidPublicKeyError.ts
@@ -1,0 +1,1 @@
+export default class InvalidPublicKeyError extends Error {}

--- a/credentials/SorobanApi.credentials.ts
+++ b/credentials/SorobanApi.credentials.ts
@@ -11,12 +11,13 @@ export class SorobanApi implements ICredentialType {
 			type: 'options',
 			default: '',
 			options: [
-				{ name: 'Futurenet', value: 'futurenet' },
+				{ name: 'Soroban RPC', value: 'sorobanRpc' },
+				{ name: 'Horizon RPC ', value: 'horizonRpc' },
 				{ name: 'Custom', value: 'custom' },
 			],
 		},
 		{
-			displayName: 'Futurenet URL',
+			displayName: 'Soroban RPC URL',
 			name: 'networkUrl',
 			type: 'string',
 			required: true,
@@ -26,7 +27,7 @@ export class SorobanApi implements ICredentialType {
 				},
 			},
 			default: '',
-			placeholder: 'https://horizon-futurenet.stellar.org',
+			placeholder: 'https://rpc-futurenet.stellar.org',
 		},
 		{
 			displayName: 'Network Passphrase',

--- a/nodes/Soroban/Soroban.node.ts
+++ b/nodes/Soroban/Soroban.node.ts
@@ -41,7 +41,7 @@ export class Soroban implements INodeType {
 						value: 'newAccount',
 					},
 					{
-						name: 'Fund Account in testnet',
+						name: 'Fund Account in futurenet',
 						value: 'fundAccount',
 					},
 					{

--- a/nodes/Soroban/Soroban.node.ts
+++ b/nodes/Soroban/Soroban.node.ts
@@ -8,6 +8,7 @@ import { router } from './actions/router';
 import * as payments from './actions/payments';
 import * as newAccount from './actions/newAccount';
 import * as transaction from './actions/transaction';
+import * as fundAccount from './actions/fundAccount';
 
 export class Soroban implements INodeType {
 	description: INodeTypeDescription = {
@@ -40,6 +41,10 @@ export class Soroban implements INodeType {
 						value: 'newAccount',
 					},
 					{
+						name: 'Fund Account in testnet',
+						value: 'fundAccount',
+					},
+					{
 						name: 'Transaction',
 						value: 'transaction',
 					},
@@ -50,6 +55,7 @@ export class Soroban implements INodeType {
 			},
 			...payments.description,
 			...newAccount.description,
+			...fundAccount.description,
 			...transaction.description,
 		],
 	};

--- a/nodes/Soroban/actions/entities/SorobanNode.ts
+++ b/nodes/Soroban/actions/entities/SorobanNode.ts
@@ -4,6 +4,7 @@ export type SorobanResources = {
 	newAccount: 'createAccount';
 	transaction: 'build' | 'sign';
 	payments: 'getPayment' | 'makePayment' | 'pathPaymentStrictSend' | 'pathPaymentStrictReceive';
+	fundAccount: 'fundAccount';
 };
 
 export type Soroban = AllEntities<SorobanResources>;
@@ -11,7 +12,9 @@ export type Soroban = AllEntities<SorobanResources>;
 type SorobanNewAccount = Entity<SorobanResources, 'newAccount'>;
 type SorobanTransaction = Entity<SorobanResources, 'transaction'>;
 type SorobanPayments = Entity<SorobanResources, 'payments'>;
+type SorobanFundAccount = Entity<SorobanResources, 'fundAccount'>;
 
 export type NewAccountProperties = PropertiesOf<SorobanNewAccount>;
 export type TransactionProperties = PropertiesOf<SorobanTransaction>;
 export type PaymentsProperties = PropertiesOf<SorobanPayments>;
+export type FundAccountProperties = PropertiesOf<SorobanFundAccount>;

--- a/nodes/Soroban/actions/fundAccount/description.ts
+++ b/nodes/Soroban/actions/fundAccount/description.ts
@@ -1,0 +1,26 @@
+import { FundAccountProperties } from '../entities/SorobanNode';
+
+const description: FundAccountProperties = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		default: 'fundAccount',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['fundAccount'],
+			},
+		},
+		options: [
+			{
+				name: 'Fund Account with Friendbot',
+				value: 'fundAccount',
+				description: 'Get testnet lumens',
+				action: 'Fund account in testnet',
+			},
+		],
+	},
+];
+
+export default description;

--- a/nodes/Soroban/actions/fundAccount/description.ts
+++ b/nodes/Soroban/actions/fundAccount/description.ts
@@ -16,8 +16,8 @@ const description: FundAccountProperties = [
 			{
 				name: 'Fund Account with Friendbot',
 				value: 'fundAccount',
-				description: 'Get testnet lumens',
-				action: 'Fund account in testnet',
+				description: 'Get futurenet lumens',
+				action: 'Fund account in futurenet',
 			},
 		],
 	},

--- a/nodes/Soroban/actions/fundAccount/fundAccount/execute.ts
+++ b/nodes/Soroban/actions/fundAccount/fundAccount/execute.ts
@@ -1,0 +1,25 @@
+import StellarSdk from 'stellar-sdk';
+import type { IExecuteFunctions, IHttpRequestOptions } from 'n8n-workflow';
+import InvalidPublicKeyError from '../../../../../common/errors/stellar/InvalidPublicKeyError';
+
+const FRIENDBOT_URL = 'https://friendbot-futurenet.stellar.org/?addr=';
+
+export async function fundAccount(this: IExecuteFunctions) {
+	try {
+		const items = this.getInputData();
+		const publicKey = items[0].json.publicKey as string;
+
+		if (StellarSdk.StrKey.isValidEd25519PublicKey(publicKey)) {
+			const fundAccountRequest: IHttpRequestOptions = {
+				url: `${FRIENDBOT_URL}${publicKey}`,
+				method: 'GET',
+			};
+			await this.helpers.httpRequest(fundAccountRequest);
+		} else {
+			throw new InvalidPublicKeyError('Invalid public key');
+		}
+		return { accountFunded: publicKey };
+	} catch (error) {
+		throw new Error(error);
+	}
+}

--- a/nodes/Soroban/actions/fundAccount/fundAccount/execute.ts
+++ b/nodes/Soroban/actions/fundAccount/fundAccount/execute.ts
@@ -6,10 +6,12 @@ const FRIENDBOT_URL = 'https://friendbot-futurenet.stellar.org/?addr=';
 
 export async function fundAccount(this: IExecuteFunctions) {
 	try {
-		const items = this.getInputData();
-		const publicKey = items[0].json.publicKey as string;
+		const [item] = this.getInputData();
+		const {
+			json: { publicKey },
+		} = item;
 
-		if (StrKey.isValidEd25519PublicKey(publicKey)) {
+		if (StrKey.isValidEd25519PublicKey(publicKey as string)) {
 			const fundAccountRequest: IHttpRequestOptions = {
 				url: `${FRIENDBOT_URL}${publicKey}`,
 				method: 'GET',

--- a/nodes/Soroban/actions/fundAccount/fundAccount/execute.ts
+++ b/nodes/Soroban/actions/fundAccount/fundAccount/execute.ts
@@ -1,4 +1,4 @@
-import StellarSdk from 'stellar-sdk';
+import { StrKey } from 'soroban-client';
 import type { IExecuteFunctions, IHttpRequestOptions } from 'n8n-workflow';
 import InvalidPublicKeyError from '../../../../../common/errors/stellar/InvalidPublicKeyError';
 
@@ -9,7 +9,7 @@ export async function fundAccount(this: IExecuteFunctions) {
 		const items = this.getInputData();
 		const publicKey = items[0].json.publicKey as string;
 
-		if (StellarSdk.StrKey.isValidEd25519PublicKey(publicKey)) {
+		if (StrKey.isValidEd25519PublicKey(publicKey)) {
 			const fundAccountRequest: IHttpRequestOptions = {
 				url: `${FRIENDBOT_URL}${publicKey}`,
 				method: 'GET',

--- a/nodes/Soroban/actions/fundAccount/fundAccount/index.ts
+++ b/nodes/Soroban/actions/fundAccount/fundAccount/index.ts
@@ -1,0 +1,3 @@
+import { fundAccount as execute } from './execute';
+
+export { execute };

--- a/nodes/Soroban/actions/fundAccount/index.ts
+++ b/nodes/Soroban/actions/fundAccount/index.ts
@@ -1,0 +1,4 @@
+import description from './description';
+import * as fundAccount from './fundAccount';
+
+export { fundAccount, description };

--- a/nodes/Soroban/actions/resources.ts
+++ b/nodes/Soroban/actions/resources.ts
@@ -1,6 +1,7 @@
 import { SorobanResources } from './entities/SorobanNode';
 import { makePayment, pathPaymentStrictReceive, pathPaymentStrictSend } from './payments';
 import { createAccount } from './newAccount';
+import { fundAccount } from './fundAccount';
 import { build, sign } from './transaction';
 
 interface IOperations {
@@ -11,6 +12,11 @@ const resources: { [key in keyof SorobanResources]: IOperations } = {
 	newAccount: {
 		operations: {
 			createAccount: { execute: createAccount.execute },
+		},
+	},
+	fundAccount: {
+		operations: {
+			fundAccount: { execute: fundAccount.execute },
 		},
 	},
 	transaction: {

--- a/nodes/Soroban/transport/index.ts
+++ b/nodes/Soroban/transport/index.ts
@@ -1,8 +1,10 @@
 import type { IExecuteFunctions, ITriggerFunctions } from 'n8n-workflow';
 import SetNetworkError from '../../../common/errors/stellar/SetNetworkError';
 
-const SOROBAN_FUTURENET_NETWORK = 'https://horizon-futurenet.stellar.org';
-const SOROBAN_FUTURENET_PASSPHRASE = 'Test SDF Future Network ; October 2022';
+const SOROBAN_HORIZON_RPC_NETWORK = 'https://horizon-futurenet.stellar.org';
+const SOROBAN_HORIZON_RPC_PASSPHRASE = 'Test SDF Future Network ; October 2022';
+const SOROBAN_SOROBAN_RPC_NETWORK = 'https://rpc-futurenet.stellar.org';
+const SOROBAN_SOROBAN_RPC_PASSPHRASE = 'Test SDF Future Network ; October 2022';
 
 export class SorobanNetwork {
 	url: string;
@@ -21,10 +23,16 @@ export class SorobanNetwork {
 		let sorobanNetwork;
 
 		switch (network) {
-			case 'futurenet':
+			case 'sorobanRpc':
 				sorobanNetwork = new SorobanNetwork(
-					SOROBAN_FUTURENET_NETWORK,
-					SOROBAN_FUTURENET_PASSPHRASE,
+					SOROBAN_SOROBAN_RPC_NETWORK,
+					SOROBAN_SOROBAN_RPC_PASSPHRASE,
+				);
+				break;
+			case 'horizonRpc':
+				sorobanNetwork = new SorobanNetwork(
+					SOROBAN_HORIZON_RPC_NETWORK,
+					SOROBAN_HORIZON_RPC_PASSPHRASE,
 				);
 				break;
 			case 'custom':


### PR DESCRIPTION
# Summary

This PR adds a node for `fundAccount` in the Soroban platform through n8n.

# Details

- Add fundAccount action
- Add fundAccount action to the Soroban node
- Add soroban rcp futurenet network

# Evidence

![image](https://github.com/ScaleMote/flow/assets/63201795/912dba41-7ab5-40ec-8c56-65dfb242e8db)
![image](https://github.com/ScaleMote/flow/assets/63201795/89b7642d-4728-4566-a23d-d7619d5eaeb1)
![image](https://github.com/ScaleMote/flow/assets/63201795/fe530c6f-8599-427c-a27d-06d2ea6188f9)


# References

📖 [JS Soroban Client](https://stellar.github.io/js-soroban-client/)
